### PR TITLE
refactor: hero panel with sparkline metrics, view switch in toolbar

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,6 +32,27 @@
 
             @if (filterToolbar.visible$ | async) {
                 <div class="toolbar-filters">
+                    <div class="view-switch" role="tablist" aria-label="Dashboard view">
+                        <button
+                            type="button"
+                            role="tab"
+                            class="view-switch-option"
+                            [class.active]="filterToolbar.view === 'FRONTENDS'"
+                            [attr.aria-selected]="filterToolbar.view === 'FRONTENDS'"
+                            (click)="filterToolbar.setView('FRONTENDS')">
+                            Frontends
+                        </button>
+                        <button
+                            type="button"
+                            role="tab"
+                            class="view-switch-option"
+                            [class.active]="filterToolbar.view === 'SOLVERS'"
+                            [attr.aria-selected]="filterToolbar.view === 'SOLVERS'"
+                            (click)="filterToolbar.setView('SOLVERS')">
+                            Solvers
+                        </button>
+                    </div>
+
                     <div class="filter-dropdown-container chain-filter-container">
                         <button
                             type="button"
@@ -115,6 +136,9 @@
                             type="button"
                             class="filter-pill"
                             [class.is-customized]="filterToolbar.hasCustomizedFrontendSelection"
+                            [class.is-disabled]="filterToolbar.view === 'SOLVERS'"
+                            [disabled]="filterToolbar.view === 'SOLVERS'"
+                            [attr.title]="filterToolbar.view === 'SOLVERS' ? 'Switch to Frontends view to filter frontends' : null"
                             (click)="filterToolbar.toggleFrontendDropdown()">
                             <tui-icon icon="@tui.app-window" class="filter-pill-icon"></tui-icon>
                             <span class="filter-pill-label">Frontends</span>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -62,6 +62,51 @@
   margin-left: auto;
 }
 
+.view-switch {
+  display: inline-flex;
+  align-items: stretch;
+  box-sizing: border-box;
+  height: 2.25rem;
+  padding: 0;
+  border-radius: 4px;
+  background: rgba(28, 20, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  overflow: hidden;
+}
+
+.view-switch-option {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 0 0.95rem;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(245, 240, 240, 0.5);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+  white-space: nowrap;
+
+  &:hover {
+    color: rgba(245, 240, 240, 0.85);
+  }
+
+  &.active {
+    color: rgba(245, 240, 240, 0.95);
+    background: rgba(255, 255, 255, 0.06);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  }
+}
+
 .filter-dropdown-container {
   position: relative;
   z-index: 6;
@@ -75,10 +120,11 @@
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
+  box-sizing: border-box;
   height: 2.25rem;
   padding: 0 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 999px;
+  border-radius: 4px;
   background: rgba(28, 20, 20, 0.65);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
@@ -106,6 +152,15 @@
       color: #FFA69D;
     }
   }
+
+  &.is-disabled,
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+    border-color: rgba(255, 255, 255, 0.05);
+    background: rgba(28, 20, 20, 0.4);
+  }
 }
 
 .filter-pill-icon {
@@ -125,8 +180,8 @@
 .filter-pill-count {
   display: inline-flex;
   align-items: baseline;
-  padding: 0.1rem 0.5rem;
-  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
   background: rgba(255, 255, 255, 0.05);
   font-size: 0.78rem;
   font-weight: 700;
@@ -148,7 +203,7 @@
   min-width: 1.25rem;
   height: 1.25rem;
   padding: 0 0.35rem;
-  border-radius: 999px;
+  border-radius: 3px;
   background: rgba(255, 170, 122, 0.16);
   color: rgba(255, 185, 145, 0.95);
   font-size: 0.7rem;
@@ -179,7 +234,7 @@
   backdrop-filter: blur(24px) saturate(140%);
   -webkit-backdrop-filter: blur(24px) saturate(140%);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
+  border-radius: 4px;
   box-shadow:
     0 20px 50px rgba(10, 5, 5, 0.55),
     0 2px 0 rgba(255, 255, 255, 0.04) inset,
@@ -285,7 +340,7 @@
   user-select: none;
   font: inherit;
   text-align: left;
-  border-radius: 8px;
+  border-radius: 3px;
 
   &:hover {
     background: linear-gradient(90deg, rgba(255, 122, 110, 0.08), rgba(255, 122, 110, 0.02));

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { BigNumberFormatPipe } from "./big-number-format.pipe"
 import { AffiliatesChartsComponent } from "./affiliate-chart/affiliates-charts.component"
 import { SolversChartsComponent } from "./solvers-charts/solvers-charts.component"
 import { GlowingDotsComponent } from "./glowing-dots/glowing-dots.component"
+import { SparklineComponent } from "./sparkline/sparkline.component"
 
 @NgModule({
 	declarations: [
@@ -44,6 +45,7 @@ import { GlowingDotsComponent } from "./glowing-dots/glowing-dots.component"
 		ChartComponent,
 		AffiliatesChartsComponent,
 		SolversChartsComponent,
+		SparklineComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,33 +1,34 @@
 <div class="page-wrapper dots-background flex flex-column flex-grow gap-2 pb-2">
   <app-glowing-dots [numberOfDots]="14" [glowSpeed]="14"></app-glowing-dots>
 
-  <!-- Info cards -->
-  <div class="infos w-full infos-section">
-    <div tuiCardLarge tuiSurface="elevated" class="info-card h-full flex-grow-1">
-      <app-info title="Deposits" [totalValue]="totalHistory?.deposit" [lastMonthValue]="lastMonthHistory?.deposit"
-        [formatMoney]="true">
-      </app-info>
+  <!-- Hero panel: the four headline metrics with sparklines, on one elevated surface. -->
+  <section class="hero-panel">
+    <div class="hero-metrics">
+      <div class="hero-metric">
+        <div class="hero-spark"><app-sparkline [data]="depositsSpark" color="#FF7A6E"></app-sparkline></div>
+        <app-info title="Deposits" [totalValue]="totalHistory?.deposit" [lastMonthValue]="lastMonthHistory?.deposit"
+          [formatMoney]="true">
+        </app-info>
+      </div>
+      <div class="hero-metric">
+        <div class="hero-spark"><app-sparkline [data]="volumeSpark" color="#FFB36B"></app-sparkline></div>
+        <app-info title="Traded Volume" [totalValue]="totalHistory?.tradeVolume"
+          [lastMonthValue]="lastMonthHistory?.tradeVolume"
+          [formatMoney]="true">
+        </app-info>
+      </div>
+      <div class="hero-metric">
+        <div class="hero-spark"><app-sparkline [data]="quotesSpark" color="#7FD3F0"></app-sparkline></div>
+        <app-info title="Quotes" [totalValue]="totalHistory?.quotesCount" [lastMonthValue]="lastMonthHistory?.quotesCount">
+        </app-info>
+      </div>
+      <div class="hero-metric">
+        <div class="hero-spark"><app-sparkline [data]="usersSpark" color="#A98EFF"></app-sparkline></div>
+        <app-info title="Users" [totalValue]="totalHistory?.users" [lastMonthValue]="monthlyActiveUsers">
+        </app-info>
+      </div>
     </div>
-    <div tuiCardLarge tuiSurface="elevated" class="info-card h-full flex-grow-1">
-      <app-info title="Traded Volume" [totalValue]="totalHistory?.tradeVolume"
-        [lastMonthValue]="lastMonthHistory?.tradeVolume"
-        [formatMoney]="true">
-      </app-info>
-    </div>
-    <div tuiCardLarge tuiSurface="elevated" class="info-card h-full flex-grow-1">
-      <app-info title="Quotes" [totalValue]="totalHistory?.quotesCount" [lastMonthValue]="lastMonthHistory?.quotesCount">
-      </app-info>
-    </div>
-    <div tuiCardLarge tuiSurface="elevated" class="info-card h-full flex-grow-1">
-      <app-info title="Users" [totalValue]="totalHistory?.users" [lastMonthValue]="monthlyActiveUsers">
-      </app-info>
-    </div>
-  </div>
-
-  <tui-segmented size="l" class="tab-header">
-    <button type="button" class="w-full tab-button" (click)="viewMode = ViewMode.FRONTENDS">Frontends</button>
-    <button type="button" class="w-full tab-button" (click)="viewMode = ViewMode.SOLVERS">Solvers</button>
-  </tui-segmented>
+  </section>
 
   <!-- Charts -->
   <div class="charts-section">

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,70 +1,195 @@
-.info-card {
-  min-width: 12em;
-  position: relative;
-  overflow: hidden;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-
-  // Glassmorphism — let the dots and glow show through
-  background: rgba(21, 15, 15, 0.4) !important;
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(132, 125, 125, 0.08) !important;
-
-  // Top accent border
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(
-      90deg,
-      rgba(233, 76, 61, 0.6) 0%,
-      rgba(255, 122, 110, 0.4) 50%,
-      rgba(233, 76, 61, 0.2) 100%
-    );
-    opacity: 0;
-    transition: opacity 0.2s ease;
-  }
-
-  &:hover {
-    background: rgba(21, 15, 15, 0.55) !important;
-    box-shadow: 0 4px 16px rgba(10, 5, 5, 0.3);
-    border-color: rgba(132, 125, 125, 0.15) !important;
-
-    &::before {
-      opacity: 1;
-    }
-  }
-}
-
 .page-wrapper {
   position: relative;
   overflow: hidden;
 }
 
-// Info cards row — equal size
-.infos {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
+// ---- Hero panel: filters + 4 metrics in one elevated surface ----------------
+
+.hero-panel {
+  position: relative;
+  z-index: 5;
+  isolation: isolate;
+  overflow: visible;
+  border-radius: 4px;
+  background:
+    radial-gradient(120% 60% at 0% 0%, rgba(255, 122, 110, 0.05), transparent 55%),
+    linear-gradient(180deg, rgba(28, 20, 20, 0.55), rgba(18, 12, 12, 0.55));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow:
+    0 24px 60px rgba(10, 5, 5, 0.45),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+
+  // Animated red gradient hairline along the top edge.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 1.25rem;
+    right: 1.25rem;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 122, 110, 0.55) 30%,
+      rgba(233, 76, 61, 0.85) 50%,
+      rgba(255, 122, 110, 0.55) 70%,
+      transparent 100%
+    );
+    opacity: 0.85;
+  }
 }
 
-.infos-section {
+.hero-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 1.25rem 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  flex-wrap: wrap;
+}
+
+.hero-title-block {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.hero-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(245, 240, 240, 0.62);
+}
+
+.hero-eyebrow-divider {
+  width: 1px;
+  height: 0.7rem;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.hero-eyebrow-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 122, 110, 0.85);
+
+  &::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(255, 122, 110, 0.95);
+    box-shadow: 0 0 0 3px rgba(255, 122, 110, 0.18);
+    animation: heroPulse 2.4s ease-in-out infinite;
+  }
+}
+
+@keyframes heroPulse {
+  0%, 100% { opacity: 0.95; transform: scale(1); }
+  50%      { opacity: 0.55; transform: scale(0.85); }
+}
+
+.hero-filters {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.hero-metric {
   position: relative;
-  z-index: 1;
+  padding: 1.4rem 1.5rem;
+  min-width: 0;
+  overflow: hidden;
+  transition: background 0.2s ease;
+
+  app-info {
+    position: relative;
+    z-index: 1;
+  }
+
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    top: 1.25rem;
+    bottom: 1.25rem;
+    right: 0;
+    width: 1px;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.08) 25%,
+      rgba(255, 255, 255, 0.08) 75%,
+      transparent 100%
+    );
+  }
+
+  &:hover {
+    background: linear-gradient(
+      180deg,
+      rgba(255, 122, 110, 0.04),
+      transparent 70%
+    );
+
+    .hero-spark {
+      opacity: 1;
+    }
+  }
+}
+
+.hero-spark {
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 62%;
+  z-index: 0;
+  opacity: 0.78;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  // Fade from left (transparent — keeps numbers/labels readable) to right (visible).
+  mask-image: linear-gradient(90deg, transparent 0%, rgba(0,0,0,0.25) 35%, #000 70%, #000 100%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, rgba(0,0,0,0.25) 35%, #000 70%, #000 100%);
 }
 
 @media (max-width: 75em) {
-  .infos {
+  .hero-metrics {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .hero-metric:nth-child(2)::after {
+    display: none;
+  }
+
+  .hero-metric:nth-child(1),
+  .hero-metric:nth-child(2) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   }
 }
 
 @media (max-width: 40em) {
-  .infos {
+  .hero-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .hero-metric::after { display: none; }
+
+  .hero-metric:not(:last-child) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   }
 }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -40,10 +40,15 @@ export class HomeComponent implements OnInit, OnDestroy {
 	environments: EnvironmentInterface[]
 	decimalsMap = new Map<string, number>()
 	ViewMode = ViewMode
-	viewMode: ViewMode = ViewMode.FRONTENDS
+	get viewMode(): ViewMode { return this.filterToolbar.view as ViewMode }
 	monthlyActiveUsers: any
 	zero = BigNumber(0)
+	depositsSpark: number[] = []
+	volumeSpark: number[] = []
+	quotesSpark: number[] = []
+	usersSpark: number[] = []
 	private readonly destroyRef = inject(DestroyRef)
+	private readonly SPARK_DAYS = 60
 
 	get selectedChainNames(): string[] { return this.filterToolbar.selectedChainNames }
 	get selectedFrontendNames(): string[] { return this.filterToolbar.selectedFrontendNames }
@@ -83,6 +88,10 @@ export class HomeComponent implements OnInit, OnDestroy {
 			.subscribe(() => this.cdr.markForCheck())
 
 		this.filterToolbar.selectedFrontendNames$
+			.pipe(takeUntilDestroyed())
+			.subscribe(() => this.cdr.markForCheck())
+
+		this.filterToolbar.view$
 			.pipe(takeUntilDestroyed())
 			.subscribe(() => this.cdr.markForCheck())
 	}
@@ -214,6 +223,8 @@ export class HomeComponent implements OnInit, OnDestroy {
 				const lastMonth = aggregated.map(a => this.getLastCalendarMonthHistories(a.dailyHistories)).flat()
 				this.lastMonthHistory = lastMonth.length > 0 ? aggregateDailyHistories(lastMonth) : undefined
 
+				this.refreshSparklines(aggregated)
+
 				this.cdr.markForCheck()
 			})
 
@@ -264,6 +275,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 	ngOnDestroy(): void {
 		this.filterToolbar.setVisible(false)
 	}
+
 
 	private aggregateAffiliateHistories(environmentResults: EnvironmentHistoryResult[]): GroupedHistory[] {
 		const out: GroupedHistory[] = []
@@ -343,6 +355,30 @@ export class HomeComponent implements OnInit, OnDestroy {
 			}
 		}
 		return [...names]
+	}
+
+	private refreshSparklines(aggregated: GroupedHistory[]): void {
+		// Sum daily histories across affiliates by timestamp, then take the last N days.
+		const byTime = new Map<number, { deposit: BigNumber; volume: BigNumber; quotes: BigNumber; users: BigNumber }>()
+		for (const ah of aggregated) {
+			for (const raw of ah.dailyHistories) {
+				const d = raw as DailyHistory
+				const t = DailyHistory.getTime(d)
+				if (t == null) continue
+				const slot = byTime.get(t) ?? { deposit: BigNumber(0), volume: BigNumber(0), quotes: BigNumber(0), users: BigNumber(0) }
+				slot.deposit = slot.deposit.plus(d.deposit ?? BigNumber(0))
+				slot.volume = slot.volume.plus(d.tradeVolume ?? BigNumber(0))
+				slot.quotes = slot.quotes.plus(d.quotesCount ?? BigNumber(0))
+				slot.users = slot.users.plus(d.activeUsers ?? BigNumber(0))
+				byTime.set(t, slot)
+			}
+		}
+		const sorted = [...byTime.entries()].sort((a, b) => a[0] - b[0])
+		const tail = sorted.slice(-this.SPARK_DAYS)
+		this.depositsSpark = tail.map(([, v]) => v.deposit.toNumber())
+		this.volumeSpark = tail.map(([, v]) => v.volume.toNumber())
+		this.quotesSpark = tail.map(([, v]) => v.quotes.toNumber())
+		this.usersSpark = tail.map(([, v]) => v.users.toNumber())
 	}
 
 	private getLastCalendarMonthHistories(histories: DailyHistory[]): DailyHistory[] {

--- a/src/app/services/filter-toolbar.service.ts
+++ b/src/app/services/filter-toolbar.service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from "@angular/core"
 import { BehaviorSubject } from "rxjs"
 
+export type DashboardView = "FRONTENDS" | "SOLVERS"
+
 /**
- * Shared state for the global filter toolbar (chains, frontends).
+ * Shared state for the global filter toolbar (chains, frontends, view scope).
  *
  * Owns the canonical selection so that AppComponent can render the filter pills
  * inside the app's top toolbar while HomeComponent (and its children) consume
@@ -23,11 +25,21 @@ export class FilterToolbarService {
 	readonly availableFrontendNames$ = new BehaviorSubject<string[]>([])
 	readonly selectedFrontendNames$ = new BehaviorSubject<string[]>([])
 
+	readonly view$ = new BehaviorSubject<DashboardView>("FRONTENDS")
+
 	hasCustomizedChainSelection = false
 	hasCustomizedFrontendSelection = false
 
 	chainDropdownOpen = false
 	frontendDropdownOpen = false
+
+	get view(): DashboardView { return this.view$.value }
+	setView(view: DashboardView): void {
+		if (this.view$.value === view) return
+		this.view$.next(view)
+		// Frontend filter is meaningless in solver view — close any open dropdown.
+		if (view === "SOLVERS") this.frontendDropdownOpen = false
+	}
 
 	get loadedChainNames(): string[] { return this.loadedChainNames$.value }
 	get ignoredChainNames(): string[] { return this.ignoredChainNames$.value }

--- a/src/app/sparkline/sparkline.component.html
+++ b/src/app/sparkline/sparkline.component.html
@@ -1,0 +1,17 @@
+@if (linePath) {
+	<svg class="sparkline" [attr.viewBox]="'0 0 ' + width + ' ' + height" preserveAspectRatio="none" aria-hidden="true">
+		<defs>
+			<linearGradient [attr.id]="uid + '-fill'" x1="0" y1="0" x2="0" y2="1">
+				<stop offset="0%" [attr.stop-color]="color" stop-opacity="0.32"></stop>
+				<stop offset="60%" [attr.stop-color]="color" stop-opacity="0.06"></stop>
+				<stop offset="100%" [attr.stop-color]="color" stop-opacity="0"></stop>
+			</linearGradient>
+			<linearGradient [attr.id]="uid + '-stroke'" x1="0" y1="0" x2="1" y2="0">
+				<stop offset="0%" [attr.stop-color]="color" stop-opacity="0.6"></stop>
+				<stop offset="100%" [attr.stop-color]="color" stop-opacity="1"></stop>
+			</linearGradient>
+		</defs>
+		<path [attr.d]="areaPath" [attr.fill]="'url(#' + uid + '-fill)'"></path>
+		<path [attr.d]="linePath" [attr.stroke]="'url(#' + uid + '-stroke)'" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+	</svg>
+}

--- a/src/app/sparkline/sparkline.component.scss
+++ b/src/app/sparkline/sparkline.component.scss
@@ -1,0 +1,13 @@
+:host {
+	display: block;
+	width: 100%;
+	height: 100%;
+	pointer-events: none;
+}
+
+.sparkline {
+	width: 100%;
+	height: 100%;
+	display: block;
+	overflow: visible;
+}

--- a/src/app/sparkline/sparkline.component.ts
+++ b/src/app/sparkline/sparkline.component.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, Input } from "@angular/core"
+
+let nextId = 0
+
+@Component({
+	selector: "app-sparkline",
+	templateUrl: "./sparkline.component.html",
+	styleUrls: ["./sparkline.component.scss"],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	standalone: false,
+})
+export class SparklineComponent {
+	readonly uid = `spark-${nextId++}`
+	readonly width = 600
+	readonly height = 120
+
+	@Input() color = "#FF7A6E"
+
+	@Input() set data(value: number[] | null | undefined) {
+		const series = (value ?? []).filter(v => Number.isFinite(v))
+		this._data = series
+		const { line, area } = this.buildPaths(series)
+		this.linePath = line
+		this.areaPath = area
+	}
+	get data(): number[] {
+		return this._data
+	}
+	private _data: number[] = []
+
+	linePath = ""
+	areaPath = ""
+
+	private buildPaths(values: number[]): { line: string; area: string } {
+		if (values.length < 2) return { line: "", area: "" }
+		const w = this.width
+		const h = this.height
+		const min = Math.min(...values)
+		const max = Math.max(...values)
+		const range = max - min || 1
+		const padY = 4
+		const usableH = h - padY * 2
+		const stepX = w / (values.length - 1)
+		const points = values.map((v, i) => {
+			const x = i * stepX
+			const y = h - padY - ((v - min) / range) * usableH
+			return [x, y] as const
+		})
+		// Catmull-Rom-ish smoothing via cubic bezier control points.
+		let line = `M ${points[0][0].toFixed(2)} ${points[0][1].toFixed(2)}`
+		for (let i = 0; i < points.length - 1; i++) {
+			const [x0, y0] = points[Math.max(0, i - 1)]
+			const [x1, y1] = points[i]
+			const [x2, y2] = points[i + 1]
+			const [x3, y3] = points[Math.min(points.length - 1, i + 2)]
+			const t = 0.18
+			const cp1x = x1 + (x2 - x0) * t
+			const cp1y = y1 + (y2 - y0) * t
+			const cp2x = x2 - (x3 - x1) * t
+			const cp2y = y2 - (y3 - y1) * t
+			line += ` C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)}, ${cp2x.toFixed(2)} ${cp2y.toFixed(2)}, ${x2.toFixed(2)} ${y2.toFixed(2)}`
+		}
+		const area = `${line} L ${w} ${h} L 0 ${h} Z`
+		return { line, area }
+	}
+}


### PR DESCRIPTION
Reshape the home page so it reads as one elevated hero panel containing the four headline metrics, with a 60-day SVG area sparkline anchored to the right side of each cell. Sparklines fade left-to-right (transparent over the number/label, fully visible past it) so the data trend is glanceable without competing with the figures.

Move the Frontends/Solvers view selector out of the page body and into the app toolbar as a compact two-segment switch alongside the chain/frontend filter pills. View state lives in FilterToolbarService and the Frontends filter pill auto-disables (and any open dropdown auto-closes) when the user is on the Solvers tab.

Square off the previously-capsule pills, dropdowns, and hero panel to a 3-4px corner radius matching the existing "Powered by" badge. Normalize box-sizing/heights so the view switch and filter pills line up at exactly 2.25rem. Tone the active view-switch state down from a saturated red gradient to a quiet white-glass tint.