### PR TITLE
chore: raise component style budgets to 8kb/16kb

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,8 +55,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "8kb",
+                  "maximumError": "16kb"
                 }
               ],
               "outputHashing": "all"
@@ -70,8 +70,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "8kb",
+                  "maximumError": "16kb"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
Recent hero/toolbar refactors pushed home.component.scss past the 10kb error budget, breaking the aggregate build on Vercel.